### PR TITLE
Adjust hold timing and add double tap hold

### DIFF
--- a/miryoku/custom_config.h
+++ b/miryoku/custom_config.h
@@ -3,6 +3,6 @@
 
 #define MIRYOKU_LAYER_BASE \
 &kp SQT,           &kp COMMA,         &kp DOT,           &kp P,             &kp Y,             &kp F,             &kp G,             &kp C,             &kp R,             &kp L,             \
-U_MT(LGUI, A),     U_MT(LALT, O),     U_MT(LCTRL, E),    U_MT(LSHFT, U),    &kp I,             &kp D,             U_MT(LSHFT, H),    U_MT(LCTRL, T),    U_MT(LALT, N),     U_MT(LGUI, S),     \
+  U_MT_LONG(LGUI, A), U_MT_LONG(LALT, O), U_MT_LONG(LCTRL, E), U_MT_SHORT(LSHFT, U), &kp I,             &kp D,             U_MT_SHORT(LSHFT, H), U_MT_LONG(LCTRL, T), U_MT_LONG(LALT, N), U_MT_LONG(LGUI, S), \
 U_LT(U_BUTTON, SLASH),U_MT(RALT, Q),     &kp J,             &kp K,             &kp X,             &kp B,             &kp M,             &kp W,             U_MT(RALT, V),     U_LT(U_BUTTON, Z), \
-U_NP,              U_NP,              U_LT(U_MEDIA, ESC),U_LT(U_NAV, TAB),U_LT(U_MOUSE, RET),U_LT(U_SYM, SPACE),  U_LT(U_NUM, BSPC), U_LT(U_FUN, DEL),  U_NP,              U_NP
+U_NP,              U_NP,              U_LT(U_MEDIA, ESC),U_LT(U_NAV, TAB),U_LT(U_MOUSE, RET),U_LT(U_SYM, SPACE),  U_LT_DTHOLD(U_NUM, BSPC), U_LT(U_FUN, DEL),  U_NP,              U_NP

--- a/miryoku/miryoku.h
+++ b/miryoku/miryoku.h
@@ -23,7 +23,7 @@
 #define U_NA &none // present but not available for use
 #define U_NU &none // available but not used
 
-#define U_TAPPING_TERM 200
+#define U_TAPPING_TERM 250
 
 #include "miryoku_clipboard.h"
 

--- a/miryoku/miryoku_behaviors.dtsi
+++ b/miryoku/miryoku_behaviors.dtsi
@@ -17,5 +17,27 @@
       flavor = "tap-preferred";
       bindings = <&mo>, <&kp>;
     };
+    u_mt_long: u_mt_long {
+      compatible = "zmk,behavior-hold-tap";
+      #binding-cells = <2>;
+      tapping-term-ms = <U_TAPPING_TERM + 50>;
+      flavor = "tap-preferred";
+      bindings = <&kp>, <&kp>;
+    };
+    u_mt_short: u_mt_short {
+      compatible = "zmk,behavior-hold-tap";
+      #binding-cells = <2>;
+      tapping-term-ms = <U_TAPPING_TERM - 50>;
+      flavor = "tap-preferred";
+      bindings = <&kp>, <&kp>;
+    };
+    u_lt_dthold: u_lt_dthold {
+      compatible = "zmk,behavior-hold-tap";
+      #binding-cells = <2>;
+      tapping-term-ms = <U_TAPPING_TERM>;
+      quick-tap-ms = <U_TAPPING_TERM>;
+      flavor = "tap-preferred";
+      bindings = <&mo>, <&kp>;
+    };
   };
 };

--- a/miryoku/miryoku_behaviors.h
+++ b/miryoku/miryoku_behaviors.h
@@ -5,3 +5,6 @@
 
 #define U_MT(MOD, TAP) &u_mt MOD TAP
 #define U_LT(LAYER, TAP) &u_lt LAYER TAP
+#define U_MT_LONG(MOD, TAP) &u_mt_long MOD TAP
+#define U_MT_SHORT(MOD, TAP) &u_mt_short MOD TAP
+#define U_LT_DTHOLD(LAYER, TAP) &u_lt_dthold LAYER TAP


### PR DESCRIPTION
## Summary
- extend Miryoku behaviours to include long/short tapping-term versions
- expose helper macros for the new behaviours
- use the new macros on homerow mods and add double tap hold for backspace
- lengthen `U_TAPPING_TERM` for a slower hold detection

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685b29e9797c832abb595d5175870ce5